### PR TITLE
Update fork go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nishanths/license/v5
+module github.com/yuri-norwood/license/v5
 
 go 1.16
 


### PR DESCRIPTION
This allows cloning my fork and specifying it via the `github.com/yuri-norwood/license/v5` package path. This won't be pushed upstream.