### PR TITLE
Align output

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,8 +20,8 @@ const (
 	usageString = `Usage: license [flags] [license-type]
 
 Flags:
-	-help     print help information
-	-list     print list of available license types
+	-help         print help information
+	-list         print list of available license types
 	-n, -name     full name to use on license (default %q)
 	-o, -output   path to output file (prints to stdout if unspecified)
 	-v, -version  print version


### PR DESCRIPTION
This prints:
```
Flags:
	-help     print help information
	-list     print list of available license types
	-n, -name     full name to use on license (default "Nishanth Shanmugham")
	-o, -output   path to output file (prints to stdout if unspecified)
	-v, -version  print version
	-y, -year     year to use on license (default "2021")
```

Let's align the flag descriptions on the same column, like before:
```
Flags:
	-help         print help information
	-list         print list of available license types
	-n, -name     full name to use on license (default "Nishanth Shanmugham")
	-o, -output   path to output file (prints to stdout if unspecified)
	-v, -version  print version
	-y, -year     year to use on license (default "2021")
```

_Originally posted by @nishanths in https://github.com/nishanths/license/pull/31#discussion_r664189001_